### PR TITLE
Secure JWT secret and add environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3001
+JWT_SECRET=your-secret-key-here
+JWT_EXPIRY=24h
+DATA_DIR=server/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 server/data/*.json
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "concurrently": "^8.2.2",
         "cors": "^2.8.5",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.3.1",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
         "proper-lockfile": "^4.1.2",
@@ -336,6 +337,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "concurrently": "^8.2.2",
     "cors": "^2.8.5",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
     "proper-lockfile": "^4.1.2",

--- a/server/config.js
+++ b/server/config.js
@@ -1,8 +1,14 @@
+require('dotenv').config();
 const path = require('path');
+
+if (!process.env.JWT_SECRET) {
+  console.error('FATAL: JWT_SECRET environment variable is required');
+  process.exit(1);
+}
 
 module.exports = {
   PORT: process.env.PORT || 3001,
-  JWT_SECRET: process.env.JWT_SECRET || 'office-chore-manager-secret-key-change-in-production',
-  JWT_EXPIRY: '24h',
-  DATA_DIR: path.join(__dirname, 'data'),
+  JWT_SECRET: process.env.JWT_SECRET,
+  JWT_EXPIRY: process.env.JWT_EXPIRY || '24h',
+  DATA_DIR: process.env.DATA_DIR || path.join(__dirname, 'data'),
 };


### PR DESCRIPTION
Closes #7

## Summary
- Remove hardcoded JWT secret fallback; server now exits on startup if `JWT_SECRET` is not set
- Add `dotenv` for loading environment variables from `.env` files
- Create `.env.example` documenting available configuration (`PORT`, `JWT_SECRET`, `JWT_EXPIRY`, `DATA_DIR`)
- Add `.env` to `.gitignore` to prevent committing secrets
- Make `JWT_EXPIRY` and `DATA_DIR` configurable via environment variables

## Test plan
- [ ] Run `npm install` to install dotenv
- [ ] Run `npm run server` with `.env` present — server starts successfully
- [ ] Remove `.env`, run `npm run server` — server exits with "FATAL: JWT_SECRET environment variable is required"
- [ ] Restore `.env`, run `npm run dev` — full app works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)